### PR TITLE
add COUNTRY_ONLY policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,117 @@
 # khatru-redbean
+
 Nostr relay server based in [khatru](https://github.com/fiatjaf/khatru)
+
+## 概要
+
+khatru-redbeanは、[khatru](https://github.com/fiatjaf/khatru)をベースにしたNostrリレーサーバーです。PostgreSQLをバックエンドとして使用し、NIP-11に対応しています。
+
+## 必要な環境
+
+- Go 1.21以上
+- PostgreSQL データベース
+
+## ビルド
+
+### バイナリのビルド
+
+```bash
+make bin
+```
+
+バイナリは `bin/khatru-redbean` に生成されます。
+
+### Dockerイメージのビルド
+
+```bash
+make build
+```
+
+### その他の開発用コマンド
+
+```bash
+# テストの実行
+make test
+
+# コードフォーマットのチェック
+make fmt
+
+# 静的解析
+make staticcheck
+
+# すべてのチェック（fmt + test + staticcheck）
+make check
+
+# 開発ツールのセットアップ
+make setup
+
+# クリーンアップ
+make clean
+```
+
+## 環境変数
+
+以下の環境変数を設定してください：
+
+| 環境変数 | 必須 | 説明 | 例 |
+|---------|------|------|-----|
+| `DATABASE_URL` | ✅ | PostgreSQLデータベースの接続URL | `postgres://user:password@localhost:5432/nostr?sslmode=disable` |
+| `COUNTRY_ONLY` | ❌ | 特定の国からのアクセスのみを許可する（Cloudflareのカントリーコード） | `JP` |
+
+### 環境変数の設定例
+
+```bash
+export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
+export COUNTRY_ONLY="JP"
+```
+
+## 使い方
+
+### サーバーの起動
+
+```bash
+./bin/khatru-redbean serve [オプション]
+```
+
+### コマンドラインオプション
+
+| オプション | 短縮形 | デフォルト | 説明 |
+|-----------|-------|-----------|------|
+| `--port` | `-p` | `9999` | リッスンポート番号 |
+
+## 実行例
+
+### デフォルトポート（9999）で起動
+
+```bash
+export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
+./bin/khatru-redbean serve
+```
+
+### カスタムポートで起動
+
+```bash
+export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
+./bin/khatru-redbean serve --port 8080
+```
+
+### 日本からのアクセスのみ許可
+
+```bash
+export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
+export COUNTRY_ONLY="JP"
+./bin/khatru-redbean serve
+```
+
+## 機能
+
+- ✅ PostgreSQLバックエンドによるイベントの永続化
+- ✅ NIP-11（リレー情報ドキュメント）対応
+- ✅ 国別アクセス制限（Cloudflare経由の場合）
+- ✅ グレースフルシャットダウン
+- ✅ 大きなタグの防止（最大100タグ）
+- ✅ NIP-01, 11, 40, 42, 70, 86 対応
+
+## シャットダウン
+
+サーバーは `Ctrl+C` または `SIGTERM` シグナルでグレースフルシャットダウンします。

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -20,7 +20,7 @@ var serveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		nip11 := config.NewNIP11InfoForredbean()
-		srv := relay.NewInstance(servePort, os.Getenv("DATABASE_URL"), nip11)
+		srv := relay.NewInstance(servePort, os.Getenv("DATABASE_URL"), os.Getenv("COUNTRY_ONLY"), nip11)
 
 		zap.S().Infow("start server")
 		srv.Start(ctx)

--- a/internal/relay/instance.go
+++ b/internal/relay/instance.go
@@ -20,13 +20,15 @@ import (
 type instance struct {
 	Port        int
 	DatabaseURL string
+	CountryOnly string // Set the Cloudflare country tag here to restrict access to a specific country.
 	Info        *nip11.RelayInformationDocument
 }
 
-func NewInstance(port int, databaseUrl string, info *nip11.RelayInformationDocument) *instance {
+func NewInstance(port int, databaseUrl string, countryOnly string, info *nip11.RelayInformationDocument) *instance {
 	return &instance{
 		Port:        port,
 		DatabaseURL: databaseUrl,
+		CountryOnly: countryOnly,
 		Info:        info,
 	}
 }
@@ -57,9 +59,7 @@ func (i *instance) Start(ctx context.Context) error {
 		// define your own policies
 		// TODO: NIP-13 (Proof of Work)
 		policies.PreventLargeTags(100),
-		func(ctx context.Context, event *nostr.Event) (reject bool, msg string) {
-			return false, "" // anyone else can
-		},
+		i.RestrictCountry, // 特定の国のみにフィルタリングする
 	)
 
 	// you can request auth by rejecting an event or a request with the prefix "auth-required: "

--- a/internal/relay/policy.go
+++ b/internal/relay/policy.go
@@ -1,1 +1,29 @@
 package relay
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fiatjaf/khatru"
+	"github.com/nbd-wtf/go-nostr"
+	"go.uber.org/zap"
+)
+
+func (i *instance) RestrictCountry(ctx context.Context, event *nostr.Event) (reject bool, msg string) {
+	if i.CountryOnly == "" {
+		return false, "" // 未設定なら無条件OK
+	}
+
+	conn := khatru.GetConnection(ctx)
+	if conn == nil {
+		zap.S().Warnw("connection information not available, rejecting event", "countryOnly", i.CountryOnly)
+		return true, "blocked: unable to verify country information"
+	}
+	country := conn.Request.Header.Get("CF-IPCountry")
+
+	// Please set the Cloudflare country tag here to restrict access to a specific country.
+	if country != i.CountryOnly {
+		return true, fmt.Sprintf("blocked: only access from %v is allowed", i.CountryOnly)
+	}
+	return false, ""
+}

--- a/internal/relay/policy_test.go
+++ b/internal/relay/policy_test.go
@@ -1,0 +1,118 @@
+package relay
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fiatjaf/khatru"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip11"
+)
+
+// contextKey is a custom type for context keys to avoid collisions.
+type contextKey int
+
+const (
+	// wsKey matches the khatru internal context key for WebSocket connections.
+	// khatru uses iota (which equals 0) as the key type.
+	wsKey contextKey = 0
+)
+
+// createMockContext は、指定されたCF-IPCountryヘッダーを持つモックコンテキストを作成します。
+func createMockContext(country string) context.Context {
+	req := httptest.NewRequest("GET", "/", nil)
+	if country != "" {
+		req.Header.Set("CF-IPCountry", country)
+	}
+
+	ws := &khatru.WebSocket{
+		Request: req,
+	}
+	//lint:ignore SA1029 khatruは内部でint型のキーを使用しているため、int(wsKey)でキャストする
+	return context.WithValue(context.Background(), int(wsKey), ws)
+}
+
+func Test_instance_RestrictCountry(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		port        int
+		databaseUrl string
+		countryOnly string
+		info        *nip11.RelayInformationDocument
+		// Named input parameters for target function.
+		ctx   context.Context
+		event *nostr.Event
+		want  bool
+		want2 string
+	}{
+		{
+			name:        "CountryOnly未設定の場合は常に許可",
+			port:        3334,
+			databaseUrl: "",
+			countryOnly: "", // 空文字列の場合は国制限なし
+			info:        &nip11.RelayInformationDocument{},
+			ctx:         context.Background(),
+			event:       &nostr.Event{},
+			want:        false, // reject = false (許可)
+			want2:       "",    // メッセージなし
+		},
+		{
+			name:        "コンテキストに接続情報がない場合はブロック",
+			port:        3334,
+			databaseUrl: "",
+			countryOnly: "JP", // 日本のみに制限
+			info:        &nip11.RelayInformationDocument{},
+			ctx:         context.Background(),
+			event:       &nostr.Event{},
+			want:        true,                                            // reject = true (ブロック)
+			want2:       "blocked: unable to verify country information", // エラーメッセージ
+		},
+		{
+			name:        "許可されていない国（US）からのアクセスはブロック",
+			port:        3334,
+			databaseUrl: "",
+			countryOnly: "JP", // 日本のみに制限
+			info:        &nip11.RelayInformationDocument{},
+			ctx:         createMockContext("US"), // CF-IPCountry: US
+			event:       &nostr.Event{},
+			want:        true, // reject = true (ブロック)
+			want2:       "blocked: only access from JP is allowed",
+		},
+		{
+			name:        "許可された国（JP）からのアクセスは許可",
+			port:        3334,
+			databaseUrl: "",
+			countryOnly: "JP", // 日本のみに制限
+			info:        &nip11.RelayInformationDocument{},
+			ctx:         createMockContext("JP"), // CF-IPCountry: JP
+			event:       &nostr.Event{},
+			want:        false, // reject = false (許可)
+			want2:       "",
+		},
+		{
+			name:        "CF-IPCountryヘッダーが空の場合はブロック",
+			port:        3334,
+			databaseUrl: "",
+			countryOnly: "JP", // 日本のみに制限
+			info:        &nip11.RelayInformationDocument{},
+			ctx:         createMockContext(""), // CF-IPCountryヘッダーなし
+			event:       &nostr.Event{},
+			want:        true, // reject = true (ブロック)
+			want2:       "blocked: only access from JP is allowed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := NewInstance(tt.port, tt.databaseUrl, tt.countryOnly, tt.info)
+			got, got2 := i.RestrictCountry(tt.ctx, tt.event)
+			if got != tt.want {
+				t.Errorf("RestrictCountry() reject = %v, want %v", got, tt.want)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("RestrictCountry() msg = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Cloudflareの`CF-IPCountry`ヘッダーを使用して、特定の国からのアクセスのみを許可する機能を追加しました。

## 変更内容

### 機能追加
- `COUNTRY_ONLY` 環境変数による国別アクセス制限機能を実装
- CloudflareのCF-IPCountryヘッダーを使用して、リクエスト元の国を判定
- 指定された国以外からのイベント投稿をブロック

### 実装詳細
- **`internal/relay/policy.go`**: `RestrictCountry` メソッドを追加
  - `COUNTRY_ONLY` 環境変数が設定されていない場合はすべてのアクセスを許可
  - 接続情報が取得できない場合は安全側に倒してブロック
  - CF-IPCountryヘッダーと設定値を比較して判定

- **`internal/relay/instance.go`**: 
  - `instance` 構造体に `CountryOnly` フィールドを追加
  - `RejectEvent` に `RestrictCountry` ポリシーを登録

### テスト
- **`internal/relay/policy_test.go`**: 包括的なテストケースを追加
  - ✅ `COUNTRY_ONLY` 未設定時は常に許可
  - ✅ コンテキストに接続情報がない場合はブロック
  - ✅ 許可されていない国からのアクセスはブロック
  - ✅ 許可された国からのアクセスは許可
  - ✅ CF-IPCountryヘッダーが空の場合はブロック

### ドキュメント
- **`README.md`**: 
  - `COUNTRY_ONLY` 環境変数の説明を追加
  - 使用例を追加（日本からのアクセスのみ許可する例）
  - ビルド方法とその他の開発用コマンドを追加

## 使い方

export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
export COUNTRY_ONLY="JP"  # 日本からのアクセスのみ許可
./bin/khatru-redbean serve## 注意事項
- この機能は **Cloudflare経由** でのアクセスにのみ有効です
- Cloudflareを使用していない環境では、CF-IPCountryヘッダーが取得できないため、すべてのイベントがブロックされます
- `COUNTRY_ONLY` を設定しない（空文字列）場合は、従来通りすべての国からのアクセスを許可します

## テスト結果
make test
# すべてのテストがパス## チェックリスト
- [x] 機能実装
- [x] ユニットテスト追加
- [x] ドキュメント更新
- [x] すべてのテストがパス