### PR TITLE
add description to NIP-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN --mount=type=bind,source=.,target=/workspace \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -a -tags netgo \
     -ldflags "-extldflags '-static' -s -w \
-    -X main.version=$(git describe --tag --abbrev=0 2>/dev/null || echo 'dev') \
-    -X main.revision=$(git rev-list -1 HEAD 2>/dev/null || echo 'unknown') \
-    -X main.build=$(git describe --tags 2>/dev/null || echo 'dev')" \
+    -X github.com/azuki774/khatru-redbean/internal/config.Version=$(git describe --tag --abbrev=0 2>/dev/null || echo 'dev') \
+    -X github.com/azuki774/khatru-redbean/internal/config.Revision=$(git rev-list -1 HEAD 2>/dev/null || echo 'unknown') \
+    -X github.com/azuki774/khatru-redbean/internal/config.Build=$(git describe --tags 2>/dev/null || echo 'dev')" \
     -o /bin/khatru-redbean ./
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ BUILD_DIR ?= bin
 PKG ?= ./
 GOOS ?= linux
 GOARCH ?= amd64
-LDFLAGS ?= -s -w -extldflags '-static'
+VERSION ?= $(shell git describe --tag --abbrev=0 2>/dev/null || echo 'dev')
+REVISION ?= $(shell git rev-list -1 HEAD 2>/dev/null || echo 'unknown')
+BUILD ?= $(shell git describe --tags 2>/dev/null || echo 'dev')
+LDFLAGS ?= -s -w -extldflags '-static' \
+	-X 'github.com/azuki774/khatru-redbean/internal/config.Version=$(VERSION)' \
+	-X 'github.com/azuki774/khatru-redbean/internal/config.Revision=$(REVISION)' \
+	-X 'github.com/azuki774/khatru-redbean/internal/config.Build=$(BUILD)'
 
 .PHONY: bin build clean tidy fmt test staticcheck check setup
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,18 @@ make clean
 |---------|------|------|-----|
 | `DATABASE_URL` | ✅ | PostgreSQLデータベースの接続URL | `postgres://user:password@localhost:5432/nostr?sslmode=disable` |
 | `COUNTRY_ONLY` | ❌ | 特定の国からのアクセスのみを許可する（Cloudflareのカントリーコード） | `JP` |
+| `DESCRIPTION` | ❌ | リレーの説明（NIP-11で表示） | `My Nostr Relay` |
+| `PUBKEY` | ❌ | リレー管理者の公開鍵（NIP-11で表示） | `npub1...` |
+| `CONTRACT` | ❌ | リレー管理者への連絡先（NIP-11で表示） | `admin@example.com` |
 
 ### 環境変数の設定例
 
 ```bash
 export DATABASE_URL="postgres://user:password@localhost:5432/nostr?sslmode=disable"
 export COUNTRY_ONLY="JP"
+export DESCRIPTION="My Nostr Relay"
+export PUBKEY="npub1..."
+export CONTRACT="admin@example.com"
 ```
 
 ## 使い方

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,7 +19,11 @@ var serveCmd = &cobra.Command{
 	Long:  `start server`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		nip11 := config.NewNIP11InfoForredbean()
+		nip11 := config.NewNIP11InfoForredbean(
+			os.Getenv("DESCRIPTION"),
+			os.Getenv("PUBKEY"),
+			os.Getenv("CONTRACT"),
+		)
 		srv := relay.NewInstance(servePort, os.Getenv("DATABASE_URL"), os.Getenv("COUNTRY_ONLY"), nip11)
 
 		zap.S().Infow("start server", "country_only", srv.CountryOnly)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ func NewNIP11InfoForredbean(description, pubkey, contract string) *nip11.RelayIn
 	nip11.Contact = contract
 	nip11.SupportedNIPs = []any{1, 11, 40, 42, 70, 86}
 	nip11.Software = "https://github.com/azuki774/khatru-redbean"
-	// Version       string `json:"version"`
+	nip11.Version = Version
 	// Limitation     *RelayLimitationDocument  `json:"limitation,omitempty"`
 	nip11.RelayCountries = []string{"JP"}
 	nip11.LanguageTags = []string{"ja"}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,12 +3,16 @@ package config
 import "github.com/nbd-wtf/go-nostr/nip11"
 
 // khatru-redbean 向けのコンフィグを設定
-func NewNIP11InfoForredbean() *nip11.RelayInformationDocument {
+func NewNIP11InfoForredbean(description, pubkey, contract string) *nip11.RelayInformationDocument {
 	var nip11 nip11.RelayInformationDocument
 	nip11.Name = "redbean"
-	nip11.Description = "khatru server customized by redbean"
-	// PubKey        string `json:"pubkey"`
-	nip11.Contact = "npub1t3hk2zz6xuq7g3gljtf8jtzt0a967f6rchmnkd39vt4egjxelgmqngqav8"
+	if description != "" {
+		nip11.Description = description
+	} else {
+		nip11.Description = "khatru server customized by redbean"
+	}
+	nip11.PubKey = pubkey
+	nip11.Contact = contract
 	nip11.SupportedNIPs = []any{1, 11, 40, 42, 70, 86}
 	nip11.Software = "https://github.com/azuki774/khatru-redbean"
 	// Version       string `json:"version"`

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,0 +1,8 @@
+package config
+
+// These variables are set via ldflags during build time
+var (
+	Version  = "dev"     // git describe --tag --abbrev=0
+	Revision = "unknown" // git rev-list -1 HEAD
+	Build    = "dev"     // git describe --tags
+)


### PR DESCRIPTION
## Git タグによるバージョン管理の実装

### 概要

NIP-11のリレー情報ドキュメントに、Git タグから自動的に取得したバージョン情報を表示する機能を追加しました。リリース時にGitタグを付けると、自動的にバージョンが更新されます。

### 変更内容

#### 1. バージョン情報変数の追加 (`internal/config/version.go`)

ビルド時に値が注入されるバージョン情報を保持する変数を定義しました。

```go
var (
    Version  = "dev"     // git describe --tag --abbrev=0
    Revision = "unknown" // git rev-list -1 HEAD
    Build    = "dev"     // git describe --tags
)
```

#### 2. NIP-11 設定の更新 (`internal/config/config.go`)

`NewNIP11InfoForredbean` 関数で、コメントアウトされていた `Version` フィールドを有効化し、Git タグからのバージョン情報を設定するようにしました。

```go
nip11.Version = Version
```

#### 3. Makefile の更新 (`Makefile`)

`bin` ターゲットで以下のGitコマンドを実行し、バージョン情報を取得して `LDFLAGS` に注入するようにしました：

```makefile
VERSION ?= $(shell git describe --tag --abbrev=0 2>/dev/null || echo 'dev')
REVISION ?= $(shell git rev-list -1 HEAD 2>/dev/null || echo 'unknown')
BUILD ?= $(shell git describe --tags 2>/dev/null || echo 'dev')
LDFLAGS ?= -s -w -extldflags '-static' \
    -X 'github.com/azuki774/khatru-redbean/internal/config.Version=$(VERSION)' \
    -X 'github.com/azuki774/khatru-redbean/internal/config.Revision=$(REVISION)' \
    -X 'github.com/azuki774/khatru-redbean/internal/config.Build=$(BUILD)'
```

#### 4. Dockerfile の修正 (`Dockerfile`)

ldflags のパスを `main.*` から `github.com/azuki774/khatru-redbean/internal/config.*` に修正しました。

```dockerfile
-ldflags "-extldflags '-static' -s -w \
    -X github.com/azuki774/khatru-redbean/internal/config.Version=$(git describe --tag --abbrev=0 2>/dev/null || echo 'dev') \
    -X github.com/azuki774/khatru-redbean/internal/config.Revision=$(git rev-list -1 HEAD 2>/dev/null || echo 'unknown') \
    -X github.com/azuki774/khatru-redbean/internal/config.Build=$(git describe --tags 2>/dev/null || echo 'dev')" \
```

### 動作

- **開発時**: `"version": "dev"` と表示
- **タグ付きリリース時**: `"version": "v1.0.0"` のようにGitタグが自動的に表示
- **バージョン情報**: NIP-11 エンドポイント（`/.well-known/nostr.json`）で確認可能

### 確認方法

```bash
# 通常ビルド（開発時）
make bin
curl -s http://localhost:9999/.well-known/nostr.json | jq .version
# "dev"

# タグ付与後
git tag v1.0.0
make bin
curl -s http://localhost:9999/.well-known/nostr.json | jq .version
# "v1.0.0"
```

### テスト

`make check` を実行し、以下のチェックがすべてパスしました：

- ✅ コードフォーマット（gofmt）
- ✅ ユニットテスト
- ✅ 静的解析（staticcheck）
