### PR TITLE
[codex] Support arm64 container images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           fetch-depth: 0  # git describeを使うために全履歴を取得
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +59,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: false
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -72,4 +76,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch:
+          - amd64
+          - arm64
 
     steps:
       - name: Checkout code
@@ -28,4 +34,4 @@ jobs:
         run: make check
 
       - name: Build binary
-        run: make bin
+        run: make bin GOARCH=${{ matrix.goarch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1.25.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.4 AS builder
 
 WORKDIR /workspace
+
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN --mount=type=bind,source=.,target=/workspace \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux go build -a -tags netgo \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -tags netgo \
     -ldflags "-extldflags '-static' -s -w \
     -X github.com/azuki774/khatru-redbean/internal/config.Version=$(git describe --tag --abbrev=0 2>/dev/null || echo 'dev') \
     -X github.com/azuki774/khatru-redbean/internal/config.Revision=$(git rev-list -1 HEAD 2>/dev/null || echo 'unknown') \

--- a/README.md
+++ b/README.md
@@ -21,11 +21,19 @@ make bin
 
 バイナリは `bin/khatru-redbean` に生成されます。
 
+`arm64` 向けにビルドする場合は以下を実行してください。
+
+```bash
+make bin GOARCH=arm64
+```
+
 ### Dockerイメージのビルド
 
 ```bash
 make build
 ```
+
+GitHub Actions では、同じタグ名で `linux/amd64` と `linux/arm64` のマルチアーキテクチャイメージを GHCR に公開します。
 
 ### その他の開発用コマンド
 


### PR DESCRIPTION
## 概要

- Docker イメージのビルドと公開を amd64/arm64 のマルチアーキテクチャに対応
- Dockerfile を buildx の TARGETARCH/TARGETOS に追従するよう修正
- Go の CI ビルド確認と README の説明を arm64 対応に更新

## 変更理由

これまで Docker の公開設定が linux/amd64 固定だったため、同じイメージ名では arm64 環境で利用できませんでした。GitHub Actions と Dockerfile の両方を見直し、同じタグで amd64/arm64 を提供できるようにしています。

## 確認内容

- `make bin GOARCH=amd64`
- `make bin GOARCH=arm64`
